### PR TITLE
Prevent the following of redirects

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -3,7 +3,7 @@
 use crate::BoxError;
 use hyper::{http::HeaderValue, Body, Request, Response};
 use log::debug;
-use reqwest::Client;
+use reqwest::{redirect::Policy, Client};
 use serde_derive::Deserialize;
 use std::collections::HashMap;
 
@@ -41,7 +41,7 @@ pub struct Proxy {
 
 impl Proxy {
     pub fn new(backends: Vec<Backend>) -> Self {
-        let client = Client::new();
+        let client = Client::builder().redirect(Policy::none()).build().unwrap();
         let backends = backends.into_iter().map(|b| (b.name, b.address)).collect();
         Proxy { backends, client }
     }


### PR DESCRIPTION
If the backend returns a 301 or 308, `fasttime` will attempt to follow the redirect (even if it is to an external domain, which causes a fatal error). This prevents this behaviour, leaving it up to the C@E guest program to decide whether to follow redirects or forward them to the client.