### PR TITLE
upgrade wasmtime*  0.22 => 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.22.0",
  "rustc-demangle",
 ]
 
@@ -200,12 +200,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
 
 [[package]]
+name = "cap-fs-ext"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae2cefc915619f790a3e60beedbf4c9ad71c53296cf144d30c00a4dd56037d6e"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "rustc_version",
+ "unsafe-io 0.5.2",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55a42a54f5452e9ae3878cc2d5275582e69ff55f12d0465f710a29d51708e08b"
+dependencies = [
+ "errno",
+ "fs-set-times",
+ "ipnet",
+ "libc",
+ "maybe-owned",
+ "once_cell",
+ "posish",
+ "rustc_version",
+ "unsafe-io 0.5.2",
+ "winapi 0.3.9",
+ "winapi-util",
+ "winx",
+]
+
+[[package]]
+name = "cap-rand"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bded20764c89470a9afabc59bfdac3957d6a0b50262e91fb27bc0b78f4119170"
+dependencies = [
+ "rand 0.8.3",
+]
+
+[[package]]
+name = "cap-std"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9b6253390e7f418fcc3c3f90a2e264ca32e8cac118fe2d7a5e3fef6c9fac05"
+dependencies = [
+ "cap-primitives",
+ "posish",
+ "rustc_version",
+ "unsafe-io 0.5.2",
+]
+
+[[package]]
+name = "cap-time-ext"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37aec3c17d6dcfbe46e0e327b97206bbac560aa8c5fa33db7740972313394b5b"
+dependencies = [
+ "cap-primitives",
+ "once_cell",
+ "posish",
+ "winx",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8de60b887edf6d74370fc8eb177040da4847d971d6234c7b13a6da324ef0caf"
 dependencies = [
- "semver",
+ "semver 0.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -314,16 +380,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpu-time"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,18 +387,18 @@ checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4066fd63b502d73eb8c5fa6bcab9c7962b05cd580f6b149ee83a8e730d8ce7fb"
+checksum = "31f782ffb172d8095cbb4c6464d85432c3bcfa8609b0bb1dc27cfd35bd90e052"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a54e4beb833a3c873a18a8fe735d73d732044004c7539a072c8faa35ccb0c60"
+checksum = "91e0910022b490bd0a65d5baa1693b0475cdbeea1c26472343f2acea1f1f55b8"
 dependencies = [
  "byteorder",
  "cranelift-bforest",
@@ -360,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54cac7cacb443658d8f0ff36a3545822613fa202c946c0891897843bc933810"
+checksum = "7cafe95cb5ac659e113549b2794a2c8d3a14f36e1a98728a6e0ea7a773be2129"
 dependencies = [
  "cranelift-codegen-shared",
  "cranelift-entity",
@@ -370,24 +426,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a109760aff76788b2cdaeefad6875a73c2b450be13906524f6c2a81e05b8d83c"
+checksum = "8d1bd002e42cc094a131a8227d06d48df28ea3b9127e5e3bc3010e079858e9af"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b044234aa32531f89a08b487630ddc6744696ec04c8123a1ad388de837f5de3"
+checksum = "e55e9043403f0dec775f317280015150e78b2352fb947d2f37407fd4ce6311c7"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5452b3e4e97538ee5ef2cc071301c69a86c7adf2770916b9d04e9727096abd93"
+checksum = "0153680ebce89aac7cad90a5442bb136faacfc86ea62587a01b8e8e79f8249c9"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -397,25 +453,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68035c10b2e80f26cc29c32fa824380877f38483504c2a47b54e7da311caaf3"
+checksum = "d742cf2c28699eeea26b9a7f6a53b5976fb4a7ca4778e736c063ab57592dc0cb"
 dependencies = [
  "cranelift-codegen",
- "raw-cpuid",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.69.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a530eb9d1c95b3309deb24c3d179d8b0ba5837ed98914a429787c395f614949d"
+checksum = "9e59effbaf9386ffa6742a737c159178f2085cf19634bcd8381caa87b48cd689"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "itertools",
+ "itertools 0.10.0",
  "log",
  "serde",
  "smallvec",
@@ -476,15 +531,6 @@ dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
-]
-
-[[package]]
-name = "cvt"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac344c7efccb80cd25bc61b2170aec26f2f693fd40e765a539a1243db48c71"
-dependencies = [
- "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -665,6 +711,7 @@ dependencies = [
  "tokio-rustls",
  "toml",
  "user-agent-parser",
+ "wasi-cap-std-sync",
  "wasmtime",
  "wasmtime-wasi",
 ]
@@ -705,6 +752,17 @@ checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00cfd3e4b3757c04b978ec990b6fbfae322691f5a089dc589aeb758ac510cd7"
+dependencies = [
+ "posish",
+ "unsafe-io 0.5.2",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1058,10 +1116,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "0.4.6"
+name = "itertools"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jobserver"
@@ -1111,9 +1178,9 @@ checksum = "3576a87f2ba00f6f106fdfcd16db1d698d648a26ad8e0573cad8537c3c362d2a"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "libloading"
@@ -1154,6 +1221,12 @@ name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "memchr"
@@ -1340,6 +1413,12 @@ name = "object"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
+
+[[package]]
+name = "object"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 dependencies = [
  "crc32fast",
  "indexmap",
@@ -1391,6 +1470,15 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "pin-project"
@@ -1449,6 +1537,20 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "posish"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ef27afcf5410098134a5ad1ca84590b396e3c8bc9b34106079debf20b0cb96"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "errno",
+ "itoa",
+ "libc",
+ "unsafe-io 0.5.2",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -1552,9 +1654,21 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.15",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.2",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -1564,7 +1678,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1577,23 +1701,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom 0.2.1",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
-name = "raw-cpuid"
-version = "8.1.2"
+name = "rand_hc"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdf7d9dbd43f3d81d94a49c1c3df73cc2b3827995147e6cf7f89d4ec5483e73"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "bitflags",
- "cc",
- "rustc_version",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -1646,6 +1777,7 @@ checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
 dependencies = [
  "log",
  "rustc-hash",
+ "serde",
  "smallvec",
 ]
 
@@ -1764,11 +1896,11 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
- "semver",
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -1841,8 +1973,17 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
  "serde",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.2",
 ]
 
 [[package]]
@@ -1850,6 +1991,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -1945,9 +2095,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
@@ -2054,6 +2204,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-interface"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb60ed894e6cb192847f0116f0c9ab6d949fb2e29e1ab584a8192f8f5b85541e"
+dependencies = [
+ "atty",
+ "bitflags",
+ "cap-fs-ext",
+ "cap-std",
+ "posish",
+ "rustc_version",
+ "unsafe-io 0.5.2",
+ "winapi 0.3.9",
+ "winx",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,7 +2234,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "rand",
+ "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -2281,6 +2448,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2315,6 +2488,24 @@ name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+
+[[package]]
+name = "unsafe-io"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd35327a2b46b3350186b75a3a337d4517e5ca08118c4e54175d49d7832578d8"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
+name = "unsafe-io"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63df423b0e746dae4021ff81873873df75aa9ed48ef9ef5770dca43c583d8265"
+dependencies = [
+ "rustc_version",
+]
 
 [[package]]
 name = "untrusted"
@@ -2390,24 +2581,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
-name = "wasi-common"
-version = "0.22.0"
+name = "wasi-cap-std-sync"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843c91a27e7b6a80bdc38b4383eec42e46bc81962dbf016f32a298c9126327a1"
+checksum = "0d03faceaadebcd4fff2fc7ff9be5327d61fda990396d3379677fac18ff4e2ed"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
- "cpu-time",
- "filetime",
- "getrandom 0.2.1",
+ "bitflags",
+ "cap-fs-ext",
+ "cap-rand",
+ "cap-std",
+ "cap-time-ext",
+ "fs-set-times",
  "lazy_static",
+ "libc",
+ "system-interface",
+ "tracing",
+ "unsafe-io 0.3.0",
+ "wasi-common",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "wasi-common"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424508503b311d67c83dd909d6237ca6474a638c7d8d40b9d654daedd1e2543a"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "cap-rand",
+ "cap-std",
  "libc",
  "thiserror",
  "tracing",
  "wiggle",
  "winapi 0.3.9",
- "winx",
- "yanix",
 ]
 
 [[package]]
@@ -2480,15 +2689,15 @@ checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
 
 [[package]]
 name = "wasmparser"
-version = "0.71.0"
+version = "0.73.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a30c99437829ede826802bfcf28500cf58df00e66cb9114df98813bc145ff1"
+checksum = "b8526ab131cbc49495a483c98954913ae7b83551adacab5e294cf77992e70ee7"
 
 [[package]]
 name = "wasmtime"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7426055cb92bd9a1e9469b48154d8d6119cd8c498c8b70284e420342c05dc45d"
+checksum = "8878f1f740127905dd8eddadfeaeea786f81856369eecc65e6c83ac909633cda"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -2515,9 +2724,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c01d9287e36921e46f5887a47007824ae5dbb9b7517a2d565660ab4471478709"
+checksum = "7b28e400f6a4d5d8e0086b3a2999e03be217a807f3f376dbdac5136a81ec6f79"
 dependencies = [
  "anyhow",
  "base64",
@@ -2536,27 +2745,28 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4134ed3a4316cd0de0e546c6004850afe472b0fa3fcdc2f2c15f8d449562d962"
+checksum = "0c0a13645a4b833dba480a18f048b8cebae06e70f9aa86313d779541cc1847ad"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-wasm",
+ "wasmparser",
  "wasmtime-environ",
 ]
 
 [[package]]
 name = "wasmtime-debug"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91fa931df6dd8af2b02606307674d3bad23f55473d5f4c809dddf7e4c4dc411"
+checksum = "a53b773abc89fed963d64969e38a08ed1cbc8fef43ac7383ad3f489e1a2b50ac"
 dependencies = [
  "anyhow",
  "gimli",
  "more-asserts",
- "object",
+ "object 0.23.0",
  "target-lexicon",
  "thiserror",
  "wasmparser",
@@ -2565,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1098871dc3120aaf8190d79153e470658bb79f63ee9ca31716711e123c28220"
+checksum = "f2bb053d9d3db2bbae51f87b11879386d472bf2b1dfdde8f413ae2ae0c8b9ddb"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
@@ -2585,9 +2795,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738bfcd1561ede8bb174215776fd7d9a95d5f0a47ca3deabe0282c55f9a89f68"
+checksum = "fcbf76a9b7da95c6099acf5610594f7e4eac462b163e75eb1fc333b6053c6e01"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -2600,7 +2810,7 @@ dependencies = [
  "gimli",
  "log",
  "more-asserts",
- "object",
+ "object 0.23.0",
  "rayon",
  "region",
  "serde",
@@ -2618,13 +2828,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-obj"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e96d77f1801131c5e86d93e42a3cf8a35402107332c202c245c83f34888a906"
+checksum = "f4909472de9ea73609551d883a27ab7c2b04a1c7b90bb3d25cf1314ccaf7f3d4"
 dependencies = [
  "anyhow",
  "more-asserts",
- "object",
+ "object 0.23.0",
  "target-lexicon",
  "wasmtime-debug",
  "wasmtime-environ",
@@ -2632,16 +2842,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-profiling"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60bb672c9d894776d7b9250dd9b4fe890f8760201ee4f53e5f2da772b6c4debb"
+checksum = "a04a0119d0a30f8341d436b834da16a3cd23115045fb024f44b062d3abd29ae7"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.0",
  "gimli",
  "lazy_static",
  "libc",
- "object",
+ "object 0.23.0",
  "scroll",
  "serde",
  "target-lexicon",
@@ -2651,9 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a978086740949eeedfefcee667b57a9e98d9a7fc0de382fcfa0da30369e3530d"
+checksum = "dac84560e3a8d378d76cc6c25cca5ad216a9ad85fc03ac06f91ecdf4bbbb62b8"
 dependencies = [
  "backtrace",
  "cc",
@@ -2673,37 +2883,34 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7b445df9bc7da40c357b0b05d6ed30c5f5376fde7ee5e86b25564ce8e54e2d"
+checksum = "6b545359011c26641fbc080eafa9e74516d4c929fd34d8d4fdb91021929bc0f4"
 dependencies = [
  "anyhow",
- "tracing",
  "wasi-common",
  "wasmtime",
- "wasmtime-runtime",
  "wasmtime-wiggle",
  "wiggle",
 ]
 
 [[package]]
 name = "wasmtime-wiggle"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a63659462abadf28ceb61f20f3456b792b16cdaf20207faea9124886aed392"
+checksum = "1200f57e8b7b9aba73fcf908e6d89aa1720d879532948653e1548c180790dc35"
 dependencies = [
  "wasmtime",
  "wasmtime-wiggle-macro",
  "wiggle",
  "wiggle-borrow",
- "witx",
 ]
 
 [[package]]
 name = "wasmtime-wiggle-macro"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e60d0d185876a2eec2b56ed470de91cf1e9860a099953ec54fd88bd28c5002ef"
+checksum = "6a38e270c5d1e318f0748847f39774f0fd036b61bd9c0781fd170921171a0573"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2779,10 +2986,11 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ca41d22d39db23fe440022aa010a84da3854e27f32e239e5ecc1d8cd2227fa"
+checksum = "b7b3d7fa155c0809b3b7c0c043fe41171d0a1d6669a7e566728c5285d52beebb"
 dependencies = [
+ "bitflags",
  "thiserror",
  "tracing",
  "wiggle-macro",
@@ -2791,18 +2999,18 @@ dependencies = [
 
 [[package]]
 name = "wiggle-borrow"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9765eec737f8a36b6060d94d34954d48f353a91694811510d08b2141cba51726"
+checksum = "f2fa06922b25613c70df086ee95dce9ad240d2a30659f4bacfc6868aeeb55009"
 dependencies = [
  "wiggle",
 ]
 
 [[package]]
 name = "wiggle-generate"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1b6a09972d1a154b0d3c4cded3469c4639fa7bc200309e053ff943b9034147"
+checksum = "fff9a8db03f14e9c1eec259353863be8818cfb5bfafa6211d4a3af409c008de8"
 dependencies = [
  "anyhow",
  "heck",
@@ -2815,9 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ed20d774be09682f68b8c519a6abaa5fc279479c048cca7db019a7fa3ce361"
+checksum = "8e3d20ca8d19ab366f4a085328344dc592396d91a99d84448fae92c177dbd42e"
 dependencies = [
  "quote",
  "syn",
@@ -2879,12 +3087,11 @@ dependencies = [
 
 [[package]]
 name = "winx"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d35176e4c7e0daf9d8da18b7e9df81a8f2358fb3d6feea775ce810f974a512"
+checksum = "a316462681accd062e32c37f9d78128691a4690764917d13bd8ea041baf2913e"
 dependencies = [
  "bitflags",
- "cvt",
  "winapi 0.3.9",
 ]
 
@@ -2920,32 +3127,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "yanix"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0504d76a87b9e77f1057d419a51acb4344b9e14eaf37dde22cf1fd0ec28901db"
-dependencies = [
- "bitflags",
- "cfg-if 1.0.0",
- "filetime",
- "libc",
- "tracing",
-]
-
-[[package]]
 name = "zstd"
-version = "0.5.3+zstd.1.4.5"
+version = "0.6.0+zstd.1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b32eaf771efa709e8308605bbf9319bf485dc1503179ec0469b611937c0cd8"
+checksum = "d4e44664feba7f2f1a9f300c1f6157f2d1bfc3c15c6f3cf4beabf3f5abe9c237"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "2.0.5+zstd.1.4.5"
+version = "3.0.0+zstd.1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfb642e0d27f64729a639c52db457e0ae906e7bc6f5fe8f5c453230400f1055"
+checksum = "d9447afcd795693ad59918c7bbffe42fdd6e467d708f3537e3dc14dc598c573f"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -2953,12 +3147,12 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.4.17+zstd.1.4.5"
+version = "1.4.19+zstd.1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89249644df056b522696b1bb9e7c18c87e8ffa3e2f0dc3b0155875d6498f01b"
+checksum = "ec24a9273d24437afb8e71b16f3d9a5d569193cccdb7896213b59f552f387674"
 dependencies = [
  "cc",
  "glob",
- "itertools",
+ "itertools 0.9.0",
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,9 @@ structopt = "0.3"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tokio-rustls = "0.22"
 user-agent-parser = "0.2.7"
-wasmtime = "0.22"
-wasmtime-wasi = "0.22"
+wasmtime = "0.23"
+wasmtime-wasi = "0.23"
+wasi-cap-std-sync = "0.23"
 chrono = "0.4"
 toml = "0.5"
 serde_derive = "1.0" # why is this needed?

--- a/src/fastly_dictionary.rs
+++ b/src/fastly_dictionary.rs
@@ -40,7 +40,7 @@ fn open(
                 addr, len, dict_out
             );
             let mut memory = memory!(caller);
-            let (_, buf) = match memory.read(addr, len) {
+            let (_, buf) = match memory.read_bytes(addr, len) {
                 Ok(result) => result,
                 _ => return Err(Trap::new("failed to read dictionary name")),
             };
@@ -84,14 +84,14 @@ fn get(
             {
                 Some(dict) => {
                     let mut memory = memory!(caller);
-                    let (_, buf) = match memory!(caller).read(key_addr, key_len) {
+                    let (_, buf) = match memory!(caller).read_bytes(key_addr, key_len) {
                         Ok(result) => result,
                         _ => return Err(Trap::new("failed to read dictionary name")),
                     };
                     let key = str::from_utf8(&buf).unwrap();
                     debug!("getting dictionary key {}", key);
                     match dict.get(key) {
-                        Some(value) => match memory.write(value_addr, &value.as_bytes()) {
+                        Some(value) => match memory.write_bytes(value_addr, &value.as_bytes()) {
                             Ok(written) => {
                                 memory.write_i32(nwritten, written as i32);
                             }

--- a/src/fastly_http_body.rs
+++ b/src/fastly_http_body.rs
@@ -100,7 +100,7 @@ fn write(
             match handler.inner.borrow_mut().bodies.get_mut(handle as usize) {
                 Some(body) => {
                     let mut mem = memory!(caller);
-                    let (read, buf) = match mem.read(addr, size) {
+                    let (read, buf) = match mem.read_bytes(addr, size) {
                         Ok((num, buf)) => (num, buf),
                         _ => return Err(Trap::new("Failed to read body memory")),
                     };
@@ -139,7 +139,7 @@ fn read(
             {
                 Some(body) => {
                     let mut memory = memory!(caller);
-                    match memory.write(buf, body.as_ref()) {
+                    match memory.write_bytes(buf, body.as_ref()) {
                         Ok(written) => {
                             debug!("fastly_http_body::read write {} bytes", written);
                             memory.write_i32(nread_out, written as i32);

--- a/src/fastly_http_resp.rs
+++ b/src/fastly_http_resp.rs
@@ -167,7 +167,7 @@ fn header_names_get(
                         Some(hdr) => {
                             let mut bytes = hdr.as_bytes().to_vec();
                             bytes.push(0); // api requires a terminating \x00 byte
-                            let written = memory.write(addr, &bytes).unwrap();
+                            let written = memory.write_bytes(addr, &bytes).unwrap();
                             memory.write_i32(nwritten_out, written as i32);
                             memory.write_i32(
                                 ending_cursor_out,
@@ -218,7 +218,7 @@ fn header_values_get(
                 .get_mut(handle as usize)
             {
                 Some(resp) => {
-                    let name = match memory.read(name_addr, name_size) {
+                    let name = match memory.read_bytes(name_addr, name_size) {
                         Ok((_, bytes)) => HeaderName::from_bytes(&bytes).unwrap(),
                         _ => return Err(Trap::new("Failed to read header name")),
                     };
@@ -236,7 +236,7 @@ fn header_values_get(
                         Some(val) => {
                             let mut bytes = val.to_vec();
                             bytes.push(0); // api requires a terminating \x00 byte
-                            let written = memory.write(addr, &bytes).unwrap();
+                            let written = memory.write_bytes(addr, &bytes).unwrap();
                             memory.write_i32(nwritten_out, written as i32);
                             memory.write_i32(
                                 ending_cursor_out,
@@ -284,7 +284,7 @@ fn header_values_set(
                 .get_mut(handle as usize)
             {
                 Some(resp) => {
-                    let name = match memory.read(name_addr, name_size) {
+                    let name = match memory.read_bytes(name_addr, name_size) {
                         Ok((_, bytes)) => match HeaderName::from_bytes(&bytes) {
                             Ok(name) => name,
                             _ => {
@@ -297,7 +297,7 @@ fn header_values_set(
                         _ => return Err(Trap::new("Failed to read header name")),
                     };
                     // values are \u{0} terminated so read one less byte
-                    let value = match memory.read(values_addr, values_size - 1) {
+                    let value = match memory.read_bytes(values_addr, values_size - 1) {
                         Ok((_, bytes)) => match HeaderValue::from_bytes(&bytes) {
                             Ok(value) => value,
                             _ => {

--- a/src/fastly_log.rs
+++ b/src/fastly_log.rs
@@ -37,7 +37,7 @@ fn endpoint_get(
                 name, name_len, endpoint_handle_out
             );
             let mut memory = memory!(caller);
-            let endpoint = match memory.read(name, name_len) {
+            let endpoint = match memory.read_bytes(name, name_len) {
                 Ok((_, bytes)) => match str::from_utf8(&bytes) {
                     Ok(name) => name.to_owned(),
                     _ => return Err(Trap::new("Invalid endpoint name")),
@@ -80,7 +80,7 @@ fn write(
             {
                 Some(endpoint) => {
                     let mut memory = memory!(caller);
-                    let message = match memory.read(msg, msg_len) {
+                    let message = match memory.read_bytes(msg, msg_len) {
                         Ok((_, bytes)) => match str::from_utf8(&bytes) {
                             Ok(data) => data.to_owned(),
                             _ => return Err(Trap::new("Invalid endpoint name")),

--- a/src/fastly_uap.rs
+++ b/src/fastly_uap.rs
@@ -40,7 +40,7 @@ fn parse(store: &Store) -> Func {
          patch_written: i32| {
             debug!("fastly_uap::parse");
             let mut memory = memory!(caller);
-            match memory.read(user_agent, user_agent_max_len) {
+            match memory.read_bytes(user_agent, user_agent_max_len) {
                 Ok((_, bytes)) => match str::from_utf8(&bytes) {
                     Ok(a) => {
                         let Product {
@@ -50,25 +50,25 @@ fn parse(store: &Store) -> Func {
                             patch,
                         } = UAP.parse_product(a);
                         if let Some(fam) = name {
-                            match memory.write(family_pos, fam.as_bytes()) {
+                            match memory.write_bytes(family_pos, fam.as_bytes()) {
                                 Ok(bytes) => memory.write_i32(family_written, bytes as i32),
                                 _ => return Err(Trap::i32_exit(FastlyStatus::ERROR.code)),
                             }
                         }
                         if let Some(maj) = major {
-                            match memory.write(major_pos, maj.as_bytes()) {
+                            match memory.write_bytes(major_pos, maj.as_bytes()) {
                                 Ok(bytes) => memory.write_i32(major_written, bytes as i32),
                                 _ => return Err(Trap::i32_exit(FastlyStatus::ERROR.code)),
                             }
                         }
                         if let Some(min) = minor {
-                            match memory.write(minor_pos, min.as_bytes()) {
+                            match memory.write_bytes(minor_pos, min.as_bytes()) {
                                 Ok(bytes) => memory.write_i32(minor_written, bytes as i32),
                                 _ => return Err(Trap::i32_exit(FastlyStatus::ERROR.code)),
                             }
                         }
                         if let Some(pat) = patch {
-                            match memory.write(patch_pos, pat.as_bytes()) {
+                            match memory.write_bytes(patch_pos, pat.as_bytes()) {
                                 Ok(bytes) => memory.write_i32(patch_written, bytes as i32),
                                 _ => return Err(Trap::i32_exit(FastlyStatus::ERROR.code)),
                             }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -7,8 +7,9 @@ use http::{request::Parts as RequestParts, response::Parts as ResponseParts};
 use hyper::{Body, Request, Response};
 use log::debug;
 use std::{cell::RefCell, collections::HashMap, net::IpAddr, rc::Rc};
+use wasi_cap_std_sync::WasiCtxBuilder;
 use wasmtime::{Linker, Module, Store, Trap};
-use wasmtime_wasi::{Wasi, WasiCtxBuilder};
+use wasmtime_wasi::Wasi;
 
 #[derive(Debug, Default)]
 pub struct Endpoint(pub String);

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -33,7 +33,7 @@ pub trait WriteMem {
         value: u32,
     );
 
-    fn write(
+    fn write_bytes(
         &mut self,
         index: i32,
         bytes: &[u8],
@@ -63,7 +63,7 @@ impl WriteMem for Memory {
         )
     }
 
-    fn write(
+    fn write_bytes(
         &mut self,
         index: i32,
         bytes: &[u8],
@@ -74,7 +74,7 @@ impl WriteMem for Memory {
 
 /// Convience api for common read operations
 pub trait ReadMem {
-    fn read(
+    fn read_bytes(
         &mut self,
         index: i32,
         amount: i32,
@@ -82,7 +82,7 @@ pub trait ReadMem {
 }
 
 impl ReadMem for Memory {
-    fn read(
+    fn read_bytes(
         &mut self,
         index: i32,
         amount: i32,


### PR DESCRIPTION
this upgrades wasmtime from 0.22 to 0.23


the hope here is to also see some improved module compile times. see https://github.com/bytecodealliance/wasmtime/issues/2662 for more info

a notable change is the previous wasmtime_wasi module now requires a context builder provided by a separate crate https://crates.io/crates/wasi-cap-std-sync. see https://github.com/bytecodealliance/wasmtime/issues/2691 for more info

wasmtime::Memory now defines its own read/write functions which means our extension fns read/write needed new names. just going with read_bytes/write_bytes for now