### PR TITLE
Update Rust toolchain to 1.49.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,5 +25,5 @@
 			"editor.defaultFormatter": "matklad.rust-analyzer"
 		}
 	},
-	"postCreateCommand": "cd tests/app && cargo +1.46.0 build --release --target wasm32-wasi && cd ../.."
+	"postCreateCommand": "cd tests/app && cargo +1.49.0 build --release --target wasm32-wasi && cd ../.."
 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -18,7 +18,7 @@ curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 source $HOME/.cargo/env
 
-rustup install 1.46
+rustup install 1.49.0
 rustup component add rustfmt --toolchain nightly
 rustup component add clippy
 

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -14,16 +14,16 @@ apt-get install -y \
   clang
 
 ## Install rustup and common components
-curl https://sh.rustup.rs -sSf | sh -s -- -y 
+curl https://sh.rustup.rs -sSf | sh -s -- -y
 
 source $HOME/.cargo/env
 
 rustup install 1.46
 rustup component add rustfmt --toolchain nightly
-rustup component add clippy 
+rustup component add clippy
 
 # add wasm target
-rustup target add wasm32-wasi --toolchain 1.46.0
+rustup target add wasm32-wasi --toolchain 1.49.0
 
 # macro expansion debugging
 cargo install cargo-expand

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,12 +79,12 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-1.46.0-cargo-${{ hashFiles('tests/app/Cargo.lock') }}
+          key: ${{ runner.os }}-1.49.0-cargo-${{ hashFiles('tests/app/Cargo.lock') }}
       - name: Set up Rust
         uses: hecrj/setup-rust-action@v1
         with:
             targets: wasm32-wasi
-            rust-version: "1.46.0"
+            rust-version: "1.49.0"
       - name: Build
         working-directory: tests/app
         run: cargo build --locked --release --target wasm32-wasi

--- a/README.md
+++ b/README.md
@@ -31,17 +31,17 @@ The fastest way to get started with [Compute@Edge](https://www.fastly.com/produc
 $ fastly compute build
 ```
 
-Alternatively, you can also build your WASM application using Rust's standard cargo tooling. 
+Alternatively, you can also build your WASM application using Rust's standard cargo tooling.
 
-> Fastly assumes a Rust toolchain version of `1.46.0`
+> Fastly assumes a Rust toolchain version of `1.49.0`
 
 ```sh
-# optionally install 1.46.0 if you have not done so already
-$ rustup install 1.46.0 --profile minimal
+# optionally install 1.49.0 if you have not done so already
+$ rustup install 1.49.0 --profile minimal
 # optionally install the wasm32 toolchain if you have not done so already
-$ rustup target add wasm32-wasi --toolchain 1.46.0
+$ rustup target add wasm32-wasi --toolchain 1.49.0
 # build a release mode .wasm executable
-$ cargo +1.46.0 build --release --target wasm32-wasi
+$ cargo +1.49.0 build --release --target wasm32-wasi
 ```
 
 To start fasttime, just provide it with the path to your Fastly Compute@Edge `.wasm` build artifact.
@@ -71,7 +71,7 @@ $ fasttime -w target/wasm32-wasi/release/app.wasm \
 This pairs well with a `cargo watch` workflow. In another terminal, run
 
 ```sh
-$ cargo +1.46.0 watch -x 'build --release --target wasm32-wasi'
+$ cargo +1.49.0 watch -x 'build --release --target wasm32-wasi'
 ```
 
 You can then make changes to your application in your text editor, have cargo automatically rebuild your application, and have `fasttime` automatically reload it as you develop your application
@@ -90,7 +90,7 @@ $ fasttime -w target/wasm32-wasi/release/app.wasm \
 
 #### 📚 dictionaries
 
-A common way to look up key-value'd information in Fastly is to use [edge dictionaries](https://docs.fastly.com/en/guides/about-edge-dictionaries). `fasttime` supports providing multiple `-d | --dictionary` flags with values of the form `{dictionary}:{key}={value},{key2}={value2}`. 
+A common way to look up key-value'd information in Fastly is to use [edge dictionaries](https://docs.fastly.com/en/guides/about-edge-dictionaries). `fasttime` supports providing multiple `-d | --dictionary` flags with values of the form `{dictionary}:{key}={value},{key2}={value2}`.
 
 ```sh
 $ fasttime -w target/wasm32-wasi/release/app.wasm \


### PR DESCRIPTION
The default for Compute@Edge is now 1.49.0

https://developer.fastly.com/learning/compute/#install-local-dependencies
https://github.com/fastly/compute-starter-kit-rust-default/blob/main/rust-toolchain