### PR TITLE
wasi-cap-std-sync,  wasmtime* => 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ structopt = "0.3"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 tokio-rustls = "0.22"
 user-agent-parser = "0.2.7"
-wasmtime = "0.23"
-wasmtime-wasi = "0.23"
-wasi-cap-std-sync = "0.23"
+wasmtime = "0.24"
+wasmtime-wasi = "0.24"
+wasi-cap-std-sync = "0.24"
 chrono = "0.4"
 toml = "0.5"
 serde_derive = "1.0" # why is this needed?


### PR DESCRIPTION
Not compiling with current versions: 

```
   Compiling wasi-cap-std-sync v0.23.0
error[E0599]: no method named `set_times` found for struct `cap_std::fs::File` in the current scope
  --> /Users/scalderon/.cargo/registry/src/github.com-1ecc6299db9ec823/wasi-cap-std-sync-0.23.0/src/file.rs:84:14
   |
84 |             .set_times(convert_systimespec(atime), convert_systimespec(mtime))?;
   |              ^^^^^^^^^ method not found in `cap_std::fs::File`
   |
```